### PR TITLE
Better configuration setting experience

### DIFF
--- a/src/cmd/search/main.go
+++ b/src/cmd/search/main.go
@@ -53,8 +53,19 @@ func run() {
 	}
 
 	if len(entries) == 0 {
-		wf.Warn("No entries found, updating. Please try again", "")
-		updateEntries(configHandler.GetURL())
+		err := updateEntries(configHandler.GetURL())
+		if err != nil {
+			log.Printf("Error while updating entries: %s", err)
+			wf.Fatal("Failed to update entries")
+			wf.SendFeedback()
+		}
+
+		// the entries have been updated, we need to update them
+		entries, err = cachedentries.GetEntries()
+		if err != nil {
+			log.Printf("Failed to get entries: %s", err)
+			wf.Fatal("Failed to get entries from cache")
+		}
 	}
 
 	for _, entry := range entries {

--- a/src/cmd/search/main.go
+++ b/src/cmd/search/main.go
@@ -15,15 +15,15 @@ import (
 var wf *aw.Workflow
 var endpoint string
 var (
-	setKey        string
-	getKey        string
-	configMode    bool
-	configHandler config.ConfigHandler
+	setKey           string
+	configItemToEdit string
+	configMode       bool
+	configHandler    config.ConfigHandler
 )
 
 func init() {
 	flag.StringVar(&setKey, "set", "", "")
-	flag.StringVar(&getKey, "get", "", "")
+	flag.StringVar(&configItemToEdit, "edit", "", "")
 	flag.BoolVar(&configMode, "config", false, "")
 	flag.Parse()
 
@@ -37,7 +37,7 @@ func run() {
 
 	if configMode {
 		// handle case when configuration mode is entered
-		configHandler.Handle(setKey, getKey, query)
+		configHandler.Handle(setKey, configItemToEdit, query)
 		return
 	}
 

--- a/src/cmd/search/main.go
+++ b/src/cmd/search/main.go
@@ -38,6 +38,7 @@ func run() {
 	if configMode {
 		// handle case when configuration mode is entered
 		configHandler.Handle(setKey, getKey, query)
+		return
 	}
 
 	endpointUrl := configHandler.GetURL()

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -69,6 +69,9 @@ func (config *ConfigHandler) Set(key string, value string) {
 func (config *ConfigHandler) ShowItems() {
 	config.wf.NewItem(fmt.Sprintf("Url: %s", config.config.Url)).
 		Var("name", "url").
+		// when the action is clicked, the input field will contain the old
+		// URL, so that editing is easy
+		Arg(config.config.Url).
 		Valid(true).
 		Autocomplete("url").
 		Subtitle("↩ to edit")

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -31,7 +31,7 @@ func NewConfigHandler(wf *aw.Workflow) ConfigHandler {
 
 // Handle handles the configuration GUI, i.e. setting and getting of config
 // variables
-func (config *ConfigHandler) Handle(setKey, getKey, query string) {
+func (config *ConfigHandler) Handle(setKey, itemToEdit, query string) {
 	// we want to save configuration for a key (done after editing)
 	if setKey != "" {
 		config.Set(setKey, query)
@@ -39,10 +39,10 @@ func (config *ConfigHandler) Handle(setKey, getKey, query string) {
 	}
 
 	// we want to edit configuration for a key
-	if getKey != "" {
+	if itemToEdit != "" {
 		if query != "" {
 			config.wf.
-				NewItem(fmt.Sprintf("Set %s to \"%s\"", getKey, query)).
+				NewItem(fmt.Sprintf("Set %s to \"%s\"", itemToEdit, query)).
 				Valid(true).
 				Var("value", query).
 				Arg(query).

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"log"
+	"net/url"
 
 	aw "github.com/deanishe/awgo"
 )
@@ -59,9 +59,17 @@ func (config *ConfigHandler) Handle(setKey, getKey, query string) {
 
 // Set the given configuration key to a value
 func (config *ConfigHandler) Set(key string, value string) {
-	log.Printf("Modifying %s to %s", key, value)
-	if err := config.wf.Config.Set(key, value, false).Do(); err != nil {
-		config.wf.FatalError(err)
+	if key == "url" {
+		_, err := url.ParseRequestURI(value)
+		if err != nil {
+			config.wf.Fatal("URL was invalid. Please enter a valid url.")
+			return
+		}
+
+		if err := config.wf.Config.Set(key, value, false).Do(); err != nil {
+			config.wf.FatalError(err)
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
- Prefill old url when editing config for URL
- Parse URL before accepting it as valid
- Exit early when config handler has finished running
- Rename edit flag to better reflect what it does
- Show entries directly after loaded for first time
